### PR TITLE
[settings] 컬러 세팅

### DIFF
--- a/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
+++ b/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2F5B869D2DCDD3D500C3ABF6 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5B869C2DCDD3D500C3ABF6 /* SnapKit */; };
 		2F5B86A22DCDD3E000C3ABF6 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5B86A12DCDD3E000C3ABF6 /* Then */; };
 		2F5B86AA2DCDEE0000C3ABF6 /* .swiftformat in Resources */ = {isa = PBXBuildFile; fileRef = 2F5B86A92DCDEE0000C3ABF6 /* .swiftformat */; };
+		468B02882DD411DF00A90492 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468B02872DD411DF00A90492 /* UIColor+.swift */; };
 		B060301F2DD26514002205F5 /* UIFont+Pretendard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B060301E2DD2650B002205F5 /* UIFont+Pretendard.swift */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +34,7 @@
 		2F5B86892DCDD37F00C3ABF6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		2F5B868C2DCDD37F00C3ABF6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		2F5B86A92DCDEE0000C3ABF6 /* .swiftformat */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftformat; sourceTree = "<group>"; };
+		468B02872DD411DF00A90492 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		B060301E2DD2650B002205F5 /* UIFont+Pretendard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Pretendard.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -127,6 +129,7 @@
 				B060301E2DD2650B002205F5 /* UIFont+Pretendard.swift */,
 				2F57833F2DD34C270075A288 /* ImageLiterals.swift */,
 				2F5783412DD34C340075A288 /* IconLiterals.swift */,
+				468B02872DD411DF00A90492 /* UIColor+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 				2F5B86932DCDD37F00C3ABF6 /* SceneDelegate.swift in Sources */,
 				2F5B86942DCDD37F00C3ABF6 /* ViewController.swift in Sources */,
 				B060301F2DD26514002205F5 /* UIFont+Pretendard.swift in Sources */,
+				468B02882DD411DF00A90492 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HOLIX_iOS/HOLIX_iOS/Global/Extension/UIColor+.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Extension/UIColor+.swift
@@ -1,0 +1,93 @@
+//
+//  UIColor+.swift
+//  HOLIX_iOS
+//
+//  Created by 임재현 on 5/14/25.
+//
+
+import UIKit
+
+extension UIColor {
+    static var main_blue: UIColor {
+        return UIColor(hex: "#3269FF")
+    }
+    
+    static var light_blue: UIColor {
+        return UIColor(hex: "F3F4FF")
+    }
+    
+    static var blue: UIColor {
+        return UIColor(hex: "#004BFB")
+    }
+    
+    static var skyblue: UIColor {
+        return UIColor(hex: "#1ABFFB")
+    }
+    
+    static var lime: UIColor {
+        return UIColor(hex: "#DEFF4E")
+    }
+    
+    static var green: UIColor {
+        return UIColor(hex: "#34C759")
+    }
+    
+    static var background: UIColor {
+        return UIColor(hex: "#434343",alpha: 0.3)
+    }
+    
+    static var alert_red: UIColor {
+        return UIColor(hex: "#FF4040")
+    }
+    
+    static var light_red: UIColor {
+        return UIColor(hex: "#FFEDED")
+    }
+    
+    static var gray01: UIColor {
+        return UIColor(hex: "#F5F5FB")
+    }
+    
+    static var gray02: UIColor {
+        return UIColor(hex: "#EEEEF4")
+    }
+    
+    static var gray03: UIColor {
+        return UIColor(hex: "#E0E0E6")
+    }
+    
+    static var gray04: UIColor {
+        return UIColor(hex: "#BDBDC3")
+    }
+    
+    static var gray05: UIColor {
+        return UIColor(hex: "9E9EA4")
+    }
+    
+    static var gray06: UIColor {
+        return UIColor(hex: "#616167")
+    }
+    
+    static var gray07: UIColor {
+        return UIColor(hex: "#424248")
+    }
+    
+}
+
+extension UIColor {
+    convenience init(hex: String, alpha: CGFloat = 1.0) {
+        var hexFormatted: String = hex.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).uppercased()
+
+        if hexFormatted.hasPrefix("#") {
+            hexFormatted = String(hexFormatted.dropFirst())
+        }
+
+        assert(hexFormatted.count == 6, "Invalid hex code used.")
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexFormatted).scanHexInt64(&rgbValue)
+
+        self.init(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
+    }
+}

--- a/HOLIX_iOS/HOLIX_iOS/Global/Extension/UIColor+.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Extension/UIColor+.swift
@@ -8,70 +8,22 @@
 import UIKit
 
 extension UIColor {
-    static var main_blue: UIColor {
-        return UIColor(hex: "#3269FF")
-    }
-    
-    static var light_blue: UIColor {
-        return UIColor(hex: "F3F4FF")
-    }
-    
-    static var blue: UIColor {
-        return UIColor(hex: "#004BFB")
-    }
-    
-    static var skyblue: UIColor {
-        return UIColor(hex: "#1ABFFB")
-    }
-    
-    static var lime: UIColor {
-        return UIColor(hex: "#DEFF4E")
-    }
-    
-    static var green: UIColor {
-        return UIColor(hex: "#34C759")
-    }
-    
-    static var background: UIColor {
-        return UIColor(hex: "#434343",alpha: 0.3)
-    }
-    
-    static var alert_red: UIColor {
-        return UIColor(hex: "#FF4040")
-    }
-    
-    static var light_red: UIColor {
-        return UIColor(hex: "#FFEDED")
-    }
-    
-    static var gray01: UIColor {
-        return UIColor(hex: "#F5F5FB")
-    }
-    
-    static var gray02: UIColor {
-        return UIColor(hex: "#EEEEF4")
-    }
-    
-    static var gray03: UIColor {
-        return UIColor(hex: "#E0E0E6")
-    }
-    
-    static var gray04: UIColor {
-        return UIColor(hex: "#BDBDC3")
-    }
-    
-    static var gray05: UIColor {
-        return UIColor(hex: "9E9EA4")
-    }
-    
-    static var gray06: UIColor {
-        return UIColor(hex: "#616167")
-    }
-    
-    static var gray07: UIColor {
-        return UIColor(hex: "#424248")
-    }
-    
+    static var main_blue = UIColor(hex: "#3269FF")
+    static var light_blue = UIColor(hex: "#F3F4FF")
+    static var blue = UIColor(hex: "#004BFB")
+    static var skyblue = UIColor(hex: "#1ABFFB")
+    static var lime = UIColor(hex: "#DEFF4E")
+    static var green = UIColor(hex: "#34C759")
+    static var background = UIColor(hex: "#434343",alpha: 0.3)
+    static var alert_red = UIColor(hex: "#FF4040")
+    static var light_red = UIColor(hex: "#FFEDED")
+    static var gray01 = UIColor(hex: "#F5F5FB")
+    static var gray02 = UIColor(hex: "#EEEEF4")
+    static var gray03 = UIColor(hex: "#E0E0E6")
+    static var gray04 = UIColor(hex: "#BDBDC3")
+    static var gray05 = UIColor(hex: "#9E9EA4")
+    static var gray06 = UIColor(hex: "#616167")
+    static var gray07 = UIColor(hex: "#424248")
 }
 
 extension UIColor {


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
피그마에 있는 hex코드와 이름을 바탕으로 UIColor Setting 작업을 했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- Global
ㄴ Extension
ㄴ UIColor+ (새로운 파일)

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

```swift
// 계산속성
static var main_blue: UIColor {
    return UIColor(hex: "#3269FF")
 }

// 저장속성
static var main_blue = UIColor(hex: "#3269FF")
```

이 부분에 대해서 문득 계산속성으로 지정하는 것과 저장속성으로 지정하는것이랑 어떤 차이가 있을까? 의문점이 생겨서 chat gpt 에게 물어봤는데요!! 

`static var` vs `static let` 비교
| 항목 | static var (계산 속성) | static let (저장 속성) |
|------|-------------------------|--------------------------|
| 정의 방식 | `static var main_blue: UIColor { return UIColor(hex: "#3269FF") }` | `static let main_blue = UIColor(hex: "#3269FF")` |
| 생성 시점 | 호출될 때마다 새로 생성 | 최초 접근 시 1회 생성 후 캐싱 |
| 성능 | 상대적으로 느림 (매번 새 인스턴스 생성) | 빠름 (이미 생성된 인스턴스를 재사용) |
| 메모리 효율 | 사용하지 않으면 메모리 사용 없음 | 앱 실행 중 메모리에 상주 |
| 값의 일관성 | 항상 새 인스턴스 반환 (같은 값이지만 주소는 다름) | 동일한 인스턴스를 반환 (참조 동일) |
| 사용 시기 | 다크모드 대응, 동적 색상 등 필요 시 | 고정된 색상값 등 재사용 목적 |
| 예시 적합성 | `UIColor { traitCollection in ... }` | `UIColor(hex: "#3269FF")` |

 💡 실무 팁
- 디자인 시스템에서 정의한 고정 색상은 `static let` 사용 권장
- 사용자 인터페이스 스타일(다크/라이트)에 따라 색이 바뀌어야 한다면 `static var`로 계산 속성 정의

라고 하더라고요.
이 부분 지금 저희 앱에는 다크모드/라이트 모드 에 따른 색상 전환이 없어서 저장속성으로 하는것이 괜찮을 것 같은데 두분 의견이 궁금합니다!!

추가로 white, black 색상은 따로 extension으로 빼지 않았는데, Xcode 기본 색상으로 사용해도 상관없을까요??
만약 필요하다면 바로 추가하도록 하겠습니다!!


## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
정욱님께서 알려주신 convenience init 으로 hex코드로 바로 color 를 적용하는 것을 사용해봤는데, color asset을 따로 지정해주지 않아서 번거롭지 않고  직관적으로 hex code로 사용할 수 있어서 편리했던 것 같습니다. 앞으로 자주 사용할 것 같아요!! 


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`UIColor`
- UIColor Extension 으로 hex Code를 입력하게되면, 맨 앞의 #을 제거하고 뒤에 색상코드를 바탕으로 알맞은 색상을 찾아서 리턴해줍니다.
```swift
extension UIColor {
    convenience init(hex: String, alpha: CGFloat = 1.0) {
        var hexFormatted: String = hex.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).uppercased()

        if hexFormatted.hasPrefix("#") {
            hexFormatted = String(hexFormatted.dropFirst())
        }

        assert(hexFormatted.count == 6, "Invalid hex code used.")
        var rgbValue: UInt64 = 0
        Scanner(string: hexFormatted).scanHexInt64(&rgbValue)

        self.init(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
            blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
    }
}

```
- static var 로 사용할 색상변수명에 각각의 색상을 지정해줌으로써, view에서 색상을 사용할때 .main_blue 와 같이 직관적으로 사용할 수 있도록 했습니다.

```swift
extension UIColor {
    static var main_blue: UIColor {
        return UIColor(hex: "#3269FF")
    }
}
// 사용예시
self.view.backgroundColor = .main_blue

```

## ✅ Check List
- [v] Merge 대상 브랜치가 올바른가?
- [v] 최종 코드가 에러 없이 잘 동작하는가?
- [v] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #6 
