### PR TITLE
[Refactor] Home 화면 UI 구성 리팩터링

### DIFF
--- a/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
+++ b/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,12 @@
 		2F5B869D2DCDD3D500C3ABF6 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5B869C2DCDD3D500C3ABF6 /* SnapKit */; };
 		2F5B86A22DCDD3E000C3ABF6 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5B86A12DCDD3E000C3ABF6 /* Then */; };
 		2F5B86AA2DCDEE0000C3ABF6 /* .swiftformat in Resources */ = {isa = PBXBuildFile; fileRef = 2F5B86A92DCDEE0000C3ABF6 /* .swiftformat */; };
+		2F648C862DD9A3FA00A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2F648C872DD9A3FA00A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2F648CE92DD9FB3B00A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2F648EEC2DDDB62800A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2F648EF02DDDB62D00A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		2F648EF12DDDB62D00A31931 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2F648F5D2DDE1ACD00A31931 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = 2F648F552DDE1ACD00A31931 /* .gitkeep */; };
 		2F648F5E2DDE1ACD00A31931 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F648F512DDE1ACD00A31931 /* Endpoint.swift */; };
 		2F648F5F2DDE1ACD00A31931 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F648F4F2DDE1ACD00A31931 /* APIService.swift */; };
@@ -30,6 +36,14 @@
 		2F648F692DDE1B3900A31931 /* CategoryBoxMenuResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F648F652DDE1B3900A31931 /* CategoryBoxMenuResponse.swift */; };
 		2F648F6A2DDE1B3900A31931 /* HomeItemResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F648F662DDE1B3900A31931 /* HomeItemResponse.swift */; };
 		2F648F6C2DDE1B7F00A31931 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F648F6B2DDE1B7F00A31931 /* UITextField.swift */; };
+		2FBBF54C2DDEF4FB00862C0D /* RecommendedClubCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5442DDEF4FB00862C0D /* RecommendedClubCell.swift */; };
+		2FBBF54D2DDEF4FB00862C0D /* RecommendedClubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5472DDEF4FB00862C0D /* RecommendedClubView.swift */; };
+		2FBBF54E2DDEF4FB00862C0D /* MyClubMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5492DDEF4FB00862C0D /* MyClubMainViewController.swift */; };
+		2FBBF54F2DDEF4FB00862C0D /* MyClubCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5432DDEF4FB00862C0D /* MyClubCell.swift */; };
+		2FBBF5502DDEF4FB00862C0D /* MyClubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5462DDEF4FB00862C0D /* MyClubView.swift */; };
+		2FBBF5572DDEF54B00862C0D /* MyClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */; };
+		2FBBF5582DDEF54B00862C0D /* RecommendedClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */; };
+		2FBBF55A2DDEF59800862C0D /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2FBBF5592DDEF59800862C0D /* Config.xcconfig */; };
 		4646CA862DD6FDDF00E21D3D /* ChattingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CA852DD6FDDF00E21D3D /* ChattingViewController.swift */; };
 		4646CAE12DD734BF00E21D3D /* BubbleLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CAE02DD734BF00E21D3D /* BubbleLabelView.swift */; };
 		4646CB612DD735EF00E21D3D /* ChattingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CB602DD735EF00E21D3D /* ChattingCell.swift */; };
@@ -69,6 +83,14 @@
 		2F648F652DDE1B3900A31931 /* CategoryBoxMenuResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryBoxMenuResponse.swift; sourceTree = "<group>"; };
 		2F648F662DDE1B3900A31931 /* HomeItemResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeItemResponse.swift; sourceTree = "<group>"; };
 		2F648F6B2DDE1B7F00A31931 /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
+		2FBBF5432DDEF4FB00862C0D /* MyClubCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubCell.swift; sourceTree = "<group>"; };
+		2FBBF5442DDEF4FB00862C0D /* RecommendedClubCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedClubCell.swift; sourceTree = "<group>"; };
+		2FBBF5462DDEF4FB00862C0D /* MyClubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubView.swift; sourceTree = "<group>"; };
+		2FBBF5472DDEF4FB00862C0D /* RecommendedClubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedClubView.swift; sourceTree = "<group>"; };
+		2FBBF5492DDEF4FB00862C0D /* MyClubMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubMainViewController.swift; sourceTree = "<group>"; };
+		2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubModel.swift; sourceTree = "<group>"; };
+		2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedClubModel.swift; sourceTree = "<group>"; };
+		2FBBF5592DDEF59800862C0D /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		4646CA852DD6FDDF00E21D3D /* ChattingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingViewController.swift; sourceTree = "<group>"; };
 		4646CAE02DD734BF00E21D3D /* BubbleLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleLabelView.swift; sourceTree = "<group>"; };
 		4646CB602DD735EF00E21D3D /* ChattingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingCell.swift; sourceTree = "<group>"; };
@@ -98,6 +120,11 @@
 		2F57841E2DD4446F0075A288 /* Home */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Home;
+			sourceTree = "<group>";
+		};
+		2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CategoryTabBar;
 			sourceTree = "<group>";
 		};
 		46EAB1EF2DD5C9060084C5A8 /* ClubDetail */ = {
@@ -132,6 +159,7 @@
 				2F5B867F2DCDD25500C3ABF6 /* .gitignore */,
 				2F5B868E2DCDD37F00C3ABF6 /* HOLIX_iOS */,
 				2F5B86682DCDD05500C3ABF6 /* Products */,
+				2FBBF5142DDEF4CF00862C0D /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -166,6 +194,7 @@
 		2F5B868D2DCDD37F00C3ABF6 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				2FBBF54B2DDEF4FB00862C0D /* MyClub */,
 				4646CA842DD6FDA400E21D3D /* Chatting */,
 				46EAB1EF2DD5C9060084C5A8 /* ClubDetail */,
 				2F57841E2DD4446F0075A288 /* Home */,
@@ -191,7 +220,7 @@
 		2F5B86982DCDD3AE00C3ABF6 /* Component */ = {
 			isa = PBXGroup;
 			children = (
-				2F5783912DD43A880075A288 /* TopTabBar */,
+				2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */,
 				468B03242DD425BD00A90492 /* CustomNavigationBar.swift */,
 				465E84392DDAE3ED00FF05BF /* CustomTextView.swift */,
 				465E848D2DDB67AB00FF05BF /* TagView.swift */,
@@ -225,9 +254,17 @@
 			path = Global;
 			sourceTree = "<group>";
 		};
+		2F648EEB2DDDB62800A31931 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		2F648F542DDE1ACD00A31931 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				2FBBF5592DDEF59800862C0D /* Config.xcconfig */,
 				2F648F4F2DDE1ACD00A31931 /* APIService.swift */,
 				2F648F512DDE1ACD00A31931 /* Endpoint.swift */,
 				2F648F522DDE1ACD00A31931 /* HTTPMethod.swift */,
@@ -248,6 +285,7 @@
 			isa = PBXGroup;
 			children = (
 				2F648F572DDE1ACD00A31931 /* StudyResponse.swift */,
+				2F648EEB2DDDB62800A31931 /* Component */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -274,11 +312,57 @@
 		2F648F672DDE1B3900A31931 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */,
+				2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */,
 				2F648F642DDE1B3900A31931 /* BannerResponse.swift */,
 				2F648F652DDE1B3900A31931 /* CategoryBoxMenuResponse.swift */,
 				2F648F662DDE1B3900A31931 /* HomeItemResponse.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		2FBBF5142DDEF4CF00862C0D /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				2F5783912DD43A880075A288 /* TopTabBar */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		2FBBF5452DDEF4FB00862C0D /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5432DDEF4FB00862C0D /* MyClubCell.swift */,
+				2FBBF5442DDEF4FB00862C0D /* RecommendedClubCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		2FBBF5482DDEF4FB00862C0D /* View */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5462DDEF4FB00862C0D /* MyClubView.swift */,
+				2FBBF5472DDEF4FB00862C0D /* RecommendedClubView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		2FBBF54A2DDEF4FB00862C0D /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5492DDEF4FB00862C0D /* MyClubMainViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		2FBBF54B2DDEF4FB00862C0D /* MyClub */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5452DDEF4FB00862C0D /* Cell */,
+				2FBBF5482DDEF4FB00862C0D /* View */,
+				2FBBF54A2DDEF4FB00862C0D /* ViewController */,
+			);
+			path = MyClub;
 			sourceTree = "<group>";
 		};
 		4646CA842DD6FDA400E21D3D /* Chatting */ = {
@@ -320,6 +404,7 @@
 				2F5783552DD376030075A288 /* Base */,
 				2F5783912DD43A880075A288 /* TopTabBar */,
 				2F57841E2DD4446F0075A288 /* Home */,
+				2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */,
 				46EAB1EF2DD5C9060084C5A8 /* ClubDetail */,
 				B06030202DD2660C002205F5 /* Font */,
 			);
@@ -376,6 +461,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F5B86AA2DCDEE0000C3ABF6 /* .swiftformat in Resources */,
+				2FBBF55A2DDEF59800862C0D /* Config.xcconfig in Resources */,
 				2F5B86802DCDD25500C3ABF6 /* .gitignore in Resources */,
 				2F5B868F2DCDD37F00C3ABF6 /* Assets.xcassets in Resources */,
 				2F5B86912DCDD37F00C3ABF6 /* LaunchScreen.storyboard in Resources */,
@@ -411,12 +497,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FBBF5572DDEF54B00862C0D /* MyClubModel.swift in Sources */,
+				2FBBF5582DDEF54B00862C0D /* RecommendedClubModel.swift in Sources */,
 				2F5B86922DCDD37F00C3ABF6 /* AppDelegate.swift in Sources */,
 				2F57841C2DD43EB20075A288 /* UIView.swift in Sources */,
+				2F648C872DD9A3FA00A31931 /* (null) in Sources */,
+				2F648C862DD9A3FA00A31931 /* (null) in Sources */,
+				2F648CE92DD9FB3B00A31931 /* (null) in Sources */,
+				2F648EEC2DDDB62800A31931 /* (null) in Sources */,
 				2F5783402DD34C270075A288 /* ImageLiterals.swift in Sources */,
 				4646CA862DD6FDDF00E21D3D /* ChattingViewController.swift in Sources */,
 				4646CB632DD7397900E21D3D /* ChattingMockData.swift in Sources */,
 				B09D88602DD47B8300AD423E /* NSAttributedString+Pretendard.swift in Sources */,
+				2F648EF02DDDB62D00A31931 /* (null) in Sources */,
+				2F648EF12DDDB62D00A31931 /* (null) in Sources */,
 				2F5783422DD34C340075A288 /* IconLiterals.swift in Sources */,
 				4646CB612DD735EF00E21D3D /* ChattingCell.swift in Sources */,
 				2F5B86932DCDD37F00C3ABF6 /* SceneDelegate.swift in Sources */,
@@ -428,6 +522,11 @@
 				465E84D62DDCAD0100FF05BF /* DividerView.swift in Sources */,
 				2F648F6C2DDE1B7F00A31931 /* UITextField.swift in Sources */,
 				2F648F5E2DDE1ACD00A31931 /* Endpoint.swift in Sources */,
+				2FBBF54C2DDEF4FB00862C0D /* RecommendedClubCell.swift in Sources */,
+				2FBBF54D2DDEF4FB00862C0D /* RecommendedClubView.swift in Sources */,
+				2FBBF54E2DDEF4FB00862C0D /* MyClubMainViewController.swift in Sources */,
+				2FBBF54F2DDEF4FB00862C0D /* MyClubCell.swift in Sources */,
+				2FBBF5502DDEF4FB00862C0D /* MyClubView.swift in Sources */,
 				2F648F5F2DDE1ACD00A31931 /* APIService.swift in Sources */,
 				2F648F682DDE1B3900A31931 /* BannerResponse.swift in Sources */,
 				2F648F692DDE1B3900A31931 /* CategoryBoxMenuResponse.swift in Sources */,

--- a/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
+++ b/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
@@ -44,6 +44,14 @@
 		2FBBF5572DDEF54B00862C0D /* MyClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */; };
 		2FBBF5582DDEF54B00862C0D /* RecommendedClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */; };
 		2FBBF55A2DDEF59800862C0D /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2FBBF5592DDEF59800862C0D /* Config.xcconfig */; };
+		2FBBF6012DDEFEC000862C0D /* BannerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5F52DDEFEC000862C0D /* BannerCell.swift */; };
+		2FBBF6022DDEFEC000862C0D /* CategoryBoxCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5F62DDEFEC000862C0D /* CategoryBoxCell.swift */; };
+		2FBBF6032DDEFEC000862C0D /* ContentCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5F72DDEFEC000862C0D /* ContentCardCell.swift */; };
+		2FBBF6042DDEFEC000862C0D /* SearchCategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5F82DDEFEC000862C0D /* SearchCategoryCell.swift */; };
+		2FBBF6052DDEFEC000862C0D /* HomeSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5FB2DDEFEC000862C0D /* HomeSectionHeader.swift */; };
+		2FBBF6062DDEFEC000862C0D /* HomeSectionLayoutFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5FD2DDEFEC000862C0D /* HomeSectionLayoutFactory.swift */; };
+		2FBBF6072DDEFEC000862C0D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF5FF2DDEFEC000862C0D /* HomeViewController.swift */; };
+		2FBBF6092DDEFECF00862C0D /* TopSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBF6082DDEFECF00862C0D /* TopSearchHeaderView.swift */; };
 		4646CA862DD6FDDF00E21D3D /* ChattingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CA852DD6FDDF00E21D3D /* ChattingViewController.swift */; };
 		4646CAE12DD734BF00E21D3D /* BubbleLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CAE02DD734BF00E21D3D /* BubbleLabelView.swift */; };
 		4646CB612DD735EF00E21D3D /* ChattingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4646CB602DD735EF00E21D3D /* ChattingCell.swift */; };
@@ -91,6 +99,14 @@
 		2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubModel.swift; sourceTree = "<group>"; };
 		2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedClubModel.swift; sourceTree = "<group>"; };
 		2FBBF5592DDEF59800862C0D /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		2FBBF5F52DDEFEC000862C0D /* BannerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerCell.swift; sourceTree = "<group>"; };
+		2FBBF5F62DDEFEC000862C0D /* CategoryBoxCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryBoxCell.swift; sourceTree = "<group>"; };
+		2FBBF5F72DDEFEC000862C0D /* ContentCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCell.swift; sourceTree = "<group>"; };
+		2FBBF5F82DDEFEC000862C0D /* SearchCategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCategoryCell.swift; sourceTree = "<group>"; };
+		2FBBF5FB2DDEFEC000862C0D /* HomeSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSectionHeader.swift; sourceTree = "<group>"; };
+		2FBBF5FD2DDEFEC000862C0D /* HomeSectionLayoutFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSectionLayoutFactory.swift; sourceTree = "<group>"; };
+		2FBBF5FF2DDEFEC000862C0D /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		2FBBF6082DDEFECF00862C0D /* TopSearchHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSearchHeaderView.swift; sourceTree = "<group>"; };
 		4646CA852DD6FDDF00E21D3D /* ChattingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingViewController.swift; sourceTree = "<group>"; };
 		4646CAE02DD734BF00E21D3D /* BubbleLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleLabelView.swift; sourceTree = "<group>"; };
 		4646CB602DD735EF00E21D3D /* ChattingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingCell.swift; sourceTree = "<group>"; };
@@ -115,11 +131,6 @@
 		2F5783912DD43A880075A288 /* TopTabBar */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = TopTabBar;
-			sourceTree = "<group>";
-		};
-		2F57841E2DD4446F0075A288 /* Home */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Home;
 			sourceTree = "<group>";
 		};
 		2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */ = {
@@ -197,7 +208,7 @@
 				2FBBF54B2DDEF4FB00862C0D /* MyClub */,
 				4646CA842DD6FDA400E21D3D /* Chatting */,
 				46EAB1EF2DD5C9060084C5A8 /* ClubDetail */,
-				2F57841E2DD4446F0075A288 /* Home */,
+				2FBBF6002DDEFEC000862C0D /* Home */,
 				2F5783552DD376030075A288 /* Base */,
 				468B03782DD4341200A90492 /* TestViewController.swift */,
 			);
@@ -365,6 +376,53 @@
 			path = MyClub;
 			sourceTree = "<group>";
 		};
+		2FBBF5F92DDEFEC000862C0D /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5F52DDEFEC000862C0D /* BannerCell.swift */,
+				2FBBF5F62DDEFEC000862C0D /* CategoryBoxCell.swift */,
+				2FBBF5F72DDEFEC000862C0D /* ContentCardCell.swift */,
+				2FBBF5F82DDEFEC000862C0D /* SearchCategoryCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		2FBBF5FA2DDEFEC000862C0D /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF6082DDEFECF00862C0D /* TopSearchHeaderView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		2FBBF5FC2DDEFEC000862C0D /* Header */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5FB2DDEFEC000862C0D /* HomeSectionHeader.swift */,
+			);
+			path = Header;
+			sourceTree = "<group>";
+		};
+		2FBBF5FE2DDEFEC000862C0D /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5FD2DDEFEC000862C0D /* HomeSectionLayoutFactory.swift */,
+			);
+			path = Layout;
+			sourceTree = "<group>";
+		};
+		2FBBF6002DDEFEC000862C0D /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				2FBBF5FA2DDEFEC000862C0D /* Component */,
+				2FBBF5FC2DDEFEC000862C0D /* Header */,
+				2FBBF5F92DDEFEC000862C0D /* Cell */,
+				2FBBF5FE2DDEFEC000862C0D /* Layout */,
+				2FBBF5FF2DDEFEC000862C0D /* HomeViewController.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		4646CA842DD6FDA400E21D3D /* Chatting */ = {
 			isa = PBXGroup;
 			children = (
@@ -403,7 +461,6 @@
 			fileSystemSynchronizedGroups = (
 				2F5783552DD376030075A288 /* Base */,
 				2F5783912DD43A880075A288 /* TopTabBar */,
-				2F57841E2DD4446F0075A288 /* Home */,
 				2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */,
 				46EAB1EF2DD5C9060084C5A8 /* ClubDetail */,
 				B06030202DD2660C002205F5 /* Font */,
@@ -506,6 +563,13 @@
 				2F648CE92DD9FB3B00A31931 /* (null) in Sources */,
 				2F648EEC2DDDB62800A31931 /* (null) in Sources */,
 				2F5783402DD34C270075A288 /* ImageLiterals.swift in Sources */,
+				2FBBF6012DDEFEC000862C0D /* BannerCell.swift in Sources */,
+				2FBBF6022DDEFEC000862C0D /* CategoryBoxCell.swift in Sources */,
+				2FBBF6032DDEFEC000862C0D /* ContentCardCell.swift in Sources */,
+				2FBBF6042DDEFEC000862C0D /* SearchCategoryCell.swift in Sources */,
+				2FBBF6052DDEFEC000862C0D /* HomeSectionHeader.swift in Sources */,
+				2FBBF6062DDEFEC000862C0D /* HomeSectionLayoutFactory.swift in Sources */,
+				2FBBF6072DDEFEC000862C0D /* HomeViewController.swift in Sources */,
 				4646CA862DD6FDDF00E21D3D /* ChattingViewController.swift in Sources */,
 				4646CB632DD7397900E21D3D /* ChattingMockData.swift in Sources */,
 				B09D88602DD47B8300AD423E /* NSAttributedString+Pretendard.swift in Sources */,
@@ -540,6 +604,7 @@
 				468B03792DD4341200A90492 /* TestViewController.swift in Sources */,
 				468B02882DD411DF00A90492 /* UIColor+.swift in Sources */,
 				4646CAE12DD734BF00E21D3D /* BubbleLabelView.swift in Sources */,
+				2FBBF6092DDEFECF00862C0D /* TopSearchHeaderView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarCell.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarCell.swift
@@ -1,0 +1,66 @@
+//
+//  CategoryTabBarCell.swift
+//  HOLIX_iOS
+//
+//  Created by 정정욱 on 5/14/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CategoryTabBarCell: UICollectionViewCell {
+
+    // MARK: - Properties
+
+    static let identifier = CategoryTabBarCell.className
+
+    // MARK: - UI Components
+
+    let titleLabel = UILabel()
+
+    // MARK: - LifeCycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setStyle()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - SetUI
+
+    private func setUI() {
+        contentView.addSubview(titleLabel)
+    }
+
+    // MARK: - SetStyle
+
+    private func setStyle() {
+        titleLabel.do {
+            $0.textAlignment = .center
+            $0.textColor = .black
+        }
+    }
+
+    // MARK: - SetLayout
+
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension CategoryTabBarCell {
+    func configure(title: String, isSelected: Bool) {
+        titleLabel.text = title
+        titleLabel.font = isSelected ? .pretendard(.body1_sb_15) : .pretendard(.body3_r_15)
+        titleLabel.textColor = .black
+    }
+}

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarView.swift
@@ -1,0 +1,180 @@
+//
+//  CategoryTopTabBar.swift
+//  HOLIX_iOS
+//
+//  Created by 정정욱 on 5/14/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CategoryTabBarView: UIView {
+
+    // MARK: - Properties
+
+    private var items: [String]
+    private var selectedIndex: Int = 0
+    private var indicatorLeadingConstraint: Constraint?
+    private var indicatorWidthConstraint: Constraint?
+
+    // MARK: - UI Components
+
+    private lazy var tabCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    )
+    private let indicatorView = UIView()
+
+    // MARK: - LifeCycle
+
+    init(items: [String]) {
+        self.items = items
+        super.init(frame: .zero)
+        setUI()
+        setDelegate()
+        setStyle()
+        setLayout()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            self.selectItem(at: 0)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setUI() {
+        addSubview(tabCollectionView)
+        tabCollectionView.addSubview(indicatorView)
+        tabCollectionView.bringSubviewToFront(indicatorView)
+    }
+
+    // MARK: - SetDelegate
+
+    private func setDelegate() {
+        tabCollectionView.delegate = self
+        tabCollectionView.dataSource = self
+    }
+
+    // MARK: - SetStyle
+
+    private func setStyle() {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = 0
+        layout.sectionInset = .zero
+
+        tabCollectionView.do {
+            $0.collectionViewLayout = layout
+            $0.showsHorizontalScrollIndicator = false
+            $0.backgroundColor = .clear
+            $0.register(CategoryTabBarCell.self, forCellWithReuseIdentifier: CategoryTabBarCell.identifier)
+        }
+
+        indicatorView.do {
+            $0.backgroundColor = .systemBlue
+        }
+    }
+
+    // MARK: - SetLayout
+
+    private func setLayout() {
+        tabCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        indicatorView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(38)
+            $0.height.equalTo(2)
+            self.indicatorLeadingConstraint = $0.leading.equalToSuperview().constraint
+            self.indicatorWidthConstraint = $0.width.equalTo(0).constraint
+        }
+    }
+
+    func selectItem(at index: Int) {
+        guard index >= 0 && index < items.count else { return }
+        selectedIndex = index
+        tabCollectionView.reloadData()
+
+        tabCollectionView.layoutIfNeeded()
+
+        tabCollectionView.scrollToItem(
+            at: IndexPath(item: index, section: 0),
+            at: .centeredHorizontally,
+            animated: true
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            self.updateIndicatorPosition(animated: true)
+        }
+    }
+
+    // MARK: - Indicator Update
+
+    func refreshIndicator() {
+        layoutIfNeeded()
+        updateIndicatorPosition(animated: false)
+    }
+
+    private func updateIndicatorPosition(animated: Bool) {
+        guard let cell = tabCollectionView.cellForItem(at: IndexPath(item: selectedIndex, section: 0)) else { return }
+        let cellFrame = cell.frame
+
+        indicatorLeadingConstraint?.update(offset: cellFrame.origin.x)
+        indicatorWidthConstraint?.update(offset: cellFrame.width)
+
+        if animated {
+            UIView.animate(withDuration: 0.25) {
+                self.tabCollectionView.layoutIfNeeded()
+            }
+        } else {
+            tabCollectionView.layoutIfNeeded()
+        }
+    }
+}
+
+// MARK: - UICollectionView Delegate & DataSource
+
+extension CategoryTabBarView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        selectItem(at: indexPath.item)
+    }
+}
+
+extension CategoryTabBarView: UICollectionViewDataSource {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        return items.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: CategoryTabBarCell.identifier,
+            for: indexPath
+        ) as? CategoryTabBarCell else {
+            return UICollectionViewCell()
+        }
+
+        let title = items[indexPath.item]
+        cell.configure(title: title, isSelected: indexPath.item == selectedIndex)
+        return cell
+    }
+}
+
+extension CategoryTabBarView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 64, height: 40)
+    }
+}

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomTextView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomTextView.swift
@@ -11,24 +11,24 @@ import SnapKit
 import Then
 
 final class CustomTextView: UIView {
-    
+
     // MARK: - Properties
-    
+
     private var plusButtonTopConstraint: Constraint?
     private var sendButtonTopConstraint: Constraint?
     private var textViewHeightConstraint: Constraint?
     var onHeightChange: ((CGFloat) -> Void)?
-   
+
     // MARK: - UI Components
-    
+
     private let plusButton = UIButton()
     private let textView = UITextView()
     private let sendButton = UIButton()
     private let tagScrollView = UIScrollView()
     private let tagStackView = UIStackView()
-    
+
     // MARK: - Lifecycle
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
@@ -36,27 +36,27 @@ final class CustomTextView: UIView {
         setLayout()
         textView.delegate = self
     }
-    
+
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - SetUI
-    
+
     private func setUI() {
         self.addSubviews(plusButton,textView,sendButton,tagScrollView)
         tagScrollView.addSubview(tagStackView)
     }
-    
+
     // MARK: - SetStyle
-    
+
     private func setStyle() {
-        
+
         plusButton.do {
             $0.setImage(.icAddCircleIos, for: .normal)
         }
-        
+
         textView.do {
             $0.backgroundColor = .white
             $0.text = "텍스트를 입력해주세요"
@@ -66,11 +66,11 @@ final class CustomTextView: UIView {
             $0.textContainerInset = UIEdgeInsets(top: 8, left: 4, bottom: 8, right: 4)
 
         }
-        
+
         sendButton.do {
             $0.setImage(.icSendIos, for: .normal)
         }
-        
+
         tagScrollView.do {
             $0.backgroundColor = .clear
             $0.showsVerticalScrollIndicator = true
@@ -80,7 +80,7 @@ final class CustomTextView: UIView {
             $0.clipsToBounds = true
             $0.isHidden = true
         }
-        
+
         tagStackView.do {
             $0.backgroundColor = .clear
             $0.axis = .horizontal
@@ -90,18 +90,18 @@ final class CustomTextView: UIView {
             $0.isHidden = true
         }
     }
-    
+
     // MARK: - SetLayout
-    
+
     private func setLayout() {
-       
+
         plusButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
             $0.size.equalTo(21)
             plusButtonTopConstraint = $0.top.equalToSuperview().offset(10).constraint
         }
 
-        
+
         textView.snp.makeConstraints {
             $0.leading.equalTo(plusButton.snp.trailing).offset(8)
             $0.trailing.equalToSuperview().inset(50)
@@ -109,13 +109,13 @@ final class CustomTextView: UIView {
             self.textViewHeightConstraint = $0.height.equalTo(40).constraint
             $0.width.equalTo(290)
         }
-        
+
         sendButton.snp.makeConstraints {
             $0.leading.equalTo(textView.snp.trailing).offset(8)
             $0.top.equalToSuperview().offset(10)
             $0.size.equalTo(21)
         }
-        
+
         tagScrollView.snp.makeConstraints {
             $0.leading.equalTo(plusButton.snp.trailing).offset(8)
             $0.trailing.equalTo(sendButton.snp.leading).offset(-8)
@@ -123,7 +123,7 @@ final class CustomTextView: UIView {
             $0.bottom.equalToSuperview().inset(1)
             $0.height.equalTo(26)
         }
-        
+
         tagStackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.height.equalTo(26)
@@ -142,7 +142,7 @@ extension CustomTextView: UITextViewDelegate {
             return
         }
     }
-        
+
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = "텍스트를 입력해주세요"
@@ -156,7 +156,7 @@ extension CustomTextView: UITextViewDelegate {
 
         let width = textView.bounds.width > 0 ? textView.bounds.width : UIScreen.main.bounds.width - 50
         let estimatedSize = textView.sizeThatFits(CGSize(width: width, height: .infinity))
-        
+
         let finalHeight = min(estimatedSize.height, maxHeight)
 
         textView.isScrollEnabled = estimatedSize.height > maxHeight
@@ -178,17 +178,17 @@ extension CustomTextView: UITextViewDelegate {
 // MARK: - Functions
 
 extension CustomTextView {
-    
+
     func movePlusButtonToBottom(_ move: Bool) {
         plusButtonTopConstraint?.deactivate()
 
         plusButton.snp.makeConstraints {
             if move {
                 plusButtonTopConstraint = $0.top.equalTo(tagScrollView.snp.top).offset(6).constraint
-                
+
                 tagScrollView.isHidden = false
                 tagStackView.isHidden = false
-                
+
             } else {
                 plusButtonTopConstraint = $0.top.equalToSuperview().offset(10).constraint
                 tagScrollView.isHidden = true
@@ -200,7 +200,7 @@ extension CustomTextView {
             self.layoutIfNeeded()
         }
     }
-    
+
     func addTag(title: String) {
            let tagView = TagListView(title: title)
            tagView.onTap = { [weak self, weak tagView] in

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/TagView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/TagView.swift
@@ -11,14 +11,14 @@ import SnapKit
 import Then
 
 final class TagListView: UIView {
-    
+
     // MARK: - Properties
     var onTap: (() -> Void)?
-    
+
     // MARK: - UI Components
-    
+
     private let tagButton = UIButton()
-  
+
     // MARK: - Lifecycle
 
     init(title: String) {
@@ -33,15 +33,15 @@ final class TagListView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - SetUI
 
     private func setUI() {
         addSubview(tagButton)
     }
-    
+
     // MARK: - SetStyle
-    
+
     private func setStyle() {
         tagButton.do {
             $0.titleLabel?.font = .pretendard(.label3_r_11)
@@ -54,15 +54,15 @@ final class TagListView: UIView {
             $0.isEnabled = false
         }
     }
-    
+
     // MARK: - SetLayout
-    
+
     private func setLayout() {
         tagButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
-    
+
     // MARK: - SetupAction
 
     private func setupAction() {

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/BubbleLabelView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/BubbleLabelView.swift
@@ -11,11 +11,11 @@ import SnapKit
 import Then
 
 final class BubbleLabelView: UIView {
-    
+
     // MARK: - UI Components
 
     private let messageLabel = UILabel()
-    
+
     // MARK: - Lifecycle
 
     init(isSender: Bool) {
@@ -28,17 +28,17 @@ final class BubbleLabelView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - SetUI
 
     private func setUI() {
         self.addSubview(messageLabel)
     }
-    
+
     // MARK: - SetStyle
-    
+
      func setStyle(isSender: Bool) {
-        
+
         messageLabel.do {
             $0.numberOfLines = 0
             $0.textColor = .white
@@ -53,9 +53,9 @@ final class BubbleLabelView: UIView {
             ? [.layerMinXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMinYCorner]
             : [.layerMaxXMinYCorner, .layerMaxXMaxYCorner, .layerMinXMinYCorner]
     }
-    
+
     // MARK: - SetLayout
-    
+
     private func setLayout() {
         messageLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(8)

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/ChattingCell.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/ChattingCell.swift
@@ -18,20 +18,20 @@ enum ChattingCellType {
 class ChattingCell: UITableViewCell {
 
     // MARK: - Properties
-    
+
     private var isSender = true
-    
+
     // MARK: - UI Components
-    
+
     private lazy var bubbleView = BubbleLabelView(isSender: true)
     private let profileImageView = UIImageView()
     private let nicknameLabel = UILabel()
     private let introductionLabel = UILabel()
     private let infoStackView = UIStackView()
     private let timeLabel = UILabel()
-    
+
      // MARK: - Lifecycle
-     
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setUI()
@@ -42,9 +42,9 @@ class ChattingCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - SetUI
-    
+
     private func setUI() {
         infoStackView.addArrangedSubview(nicknameLabel)
         infoStackView.addArrangedSubview(introductionLabel)
@@ -52,17 +52,17 @@ class ChattingCell: UITableViewCell {
     }
 
     // MARK: - SetStyle
-    
+
     private func setStyle() {
         selectionStyle = .none
         backgroundColor = .clear
-        
+
         infoStackView.do {
             $0.axis = .horizontal
             $0.spacing = 4
             $0.alignment = .center
         }
-        
+
         nicknameLabel.do {
             $0.font = .pretendard(.body6_m_13)
             $0.textColor = .darkGray
@@ -73,18 +73,18 @@ class ChattingCell: UITableViewCell {
             $0.textColor = .lightGray
             $0.text = "· 안녕하세요"
         }
-        
+
         profileImageView.do {
             $0.layer.cornerRadius = 16
             $0.clipsToBounds = true
         }
-        
+
         timeLabel.do {
             $0.font = .pretendard(.label1_b_11)
             $0.textColor = .lightGray
         }
     }
-    
+
     // MARK: - SetLayout
 
     private func setLayout() {
@@ -117,7 +117,7 @@ class ChattingCell: UITableViewCell {
 // MARK: - Configure
 
 extension ChattingCell {
-    
+
     func configure(
         with message: String,
         nickname: String? = nil,

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingMockData.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingMockData.swift
@@ -30,7 +30,7 @@ final class DummyChattingData {
     static func generate() -> [ChattingResponseDTO] {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withFullDate, .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
-        
+
         return [
             ChattingResponseDTO(
                 chattingId: 1,

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
@@ -11,14 +11,14 @@ import SnapKit
 import Then
 
 final class ChattingViewController: UIViewController {
-    
+
     // MARK: - Properties
-    
+
     private var customTextViewHeightConstraint: Constraint?
     private var customTextViewBottomConstraint: Constraint?
-    
+
     // MARK: - UI Components
-   
+
     private let customNavigationBar = CustomNavigationBar(
         titleLabel:"iOS 개발자로써 성공하고 싶은 사람들",
         hasMenuButton: true
@@ -26,9 +26,9 @@ final class ChattingViewController: UIViewController {
     private var chattingList = DummyChattingData.generate()
     private let tableView = UITableView()
     private let textView = CustomTextView()
-    
+
     // MARK: - Lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
@@ -38,7 +38,7 @@ final class ChattingViewController: UIViewController {
         tagScrollView()
         setupDismissKeyboardGesture()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         addKeyboardNotifications()
@@ -48,9 +48,9 @@ final class ChattingViewController: UIViewController {
         super.viewWillDisappear(animated)
         removeKeyboardNotifications()
     }
-    
+
     // MARK: - SetUI
-    
+
     private func setUI() {
         self.view
             .addSubviews(
@@ -59,9 +59,9 @@ final class ChattingViewController: UIViewController {
                 textView
             )
     }
-    
+
     // MARK: - SetStyle
-    
+
     private func setStyle() {
         self.view.backgroundColor = .white
         tableView.do {
@@ -69,44 +69,44 @@ final class ChattingViewController: UIViewController {
             $0.backgroundColor = .white
             $0.showsVerticalScrollIndicator = false
         }
-        
+
         textView.do {
             $0.backgroundColor = .white
         }
     }
-    
+
     // MARK: - SetLayout
-    
+
     private func setLayout() {
         customNavigationBar.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(50)
         }
-        
+
         tableView.snp.makeConstraints {
             $0.top.equalTo(customNavigationBar.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(textView.snp.top)
         }
-        
+
         textView.snp.makeConstraints {
             $0.top.equalTo(tableView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview()
             self.customTextViewBottomConstraint = $0.bottom.equalToSuperview().constraint
         }
-        
+
         textView.onHeightChange = { [weak self] newHeight in
             guard let self = self else { return }
-            
+
             self.customTextViewHeightConstraint?.update(offset: newHeight)
-            
+
             UIView.animate(withDuration: 0.2) {
                 self.view.layoutIfNeeded()
             }
         }
     }
-    
+
     private func setupTableView() {
         tableView.dataSource = self
         tableView.delegate = self
@@ -116,7 +116,7 @@ final class ChattingViewController: UIViewController {
         tableView.backgroundColor = .white
         tableView.register(ChattingCell.self, forCellReuseIdentifier: "ChattingCell")
     }
-    
+
     private func tagScrollView() {
         textView.addTag(title: "Swift")
         textView.addTag(title: "UIKit")
@@ -130,14 +130,14 @@ final class ChattingViewController: UIViewController {
 // MARK: - UITableViewDelegate,UITableViewDataSource
 
 extension ChattingViewController: UITableViewDataSource, UITableViewDelegate {
-  
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         chattingList.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "ChattingCell", for: indexPath) as? ChattingCell else { return UITableViewCell() }
-        
+
         let chat = chattingList[indexPath.row]
         cell.configure(
             with: chat.contents,
@@ -152,7 +152,7 @@ extension ChattingViewController: UITableViewDataSource, UITableViewDelegate {
 // MARK: - Keyboard
 
 extension ChattingViewController {
-    
+
     private func addKeyboardNotifications() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardWillShow(_:)),
@@ -196,8 +196,8 @@ extension ChattingViewController {
             self.textView.movePlusButtonToBottom(false)
         }
     }
-    
-    
+
+
     private func setupDismissKeyboardGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
@@ -207,5 +207,5 @@ extension ChattingViewController {
     @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
-    
+
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/Cell/SearchCategoryCell.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/Cell/SearchCategoryCell.swift
@@ -78,7 +78,7 @@ final class SearchCategoryCell: UICollectionViewCell {
         searchTextField.snp.makeConstraints {
             $0.leading.equalTo(menuButton.snp.trailing).offset(29)
             $0.centerY.equalTo(menuButton)
-            $0.width.equalTo(300)
+            $0.trailing.equalToSuperview().inset(46)
             $0.height.equalTo(40)
         }
 

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/Cell/SearchCategoryCell.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/Cell/SearchCategoryCell.swift
@@ -20,7 +20,7 @@ final class SearchCategoryCell: UICollectionViewCell {
 
     private let menuButton = UIButton()
     private let searchTextField = UITextField()
-    private let topTabBar = TopTabBarView(items: ["추천", "강의", "스터디", "북클럽", "멘토링", "커뮤니티"])
+    private let topTabBar = CategoryTabBarView(items: ["추천", "강의", "스터디", "북클럽", "멘토링", "커뮤니티"])
 
     // MARK: - LifeCycle
 

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/Component/TopSearchHeaderView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/Component/TopSearchHeaderView.swift
@@ -1,0 +1,78 @@
+//
+//  SearchBarHeaderView.swift
+//  HOLIX_iOS
+//
+//  Created by 정정욱 on 5/20/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchBarHeaderView: UIView {
+
+    // MARK: - UI Components
+
+    private let menuButton = UIButton()
+    private let searchTextField = UITextField()
+
+    // MARK: - LifeCycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+        setStyle()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setUp() {
+        addSubviews(
+            menuButton,
+            searchTextField
+        )
+    }
+
+    // MARK: - SetStyle
+
+    private func setStyle() {
+        menuButton.do {
+            $0.setImage(IconLiterals.ic_hambeger, for: .normal)
+        }
+
+        searchTextField.do {
+            $0.placeholder = "무엇을 배우고 싶으신가요?"
+            $0.layer.cornerRadius = 20
+            $0.font = .pretendard(.body3_r_15)
+            $0.textColor = .gray03
+            $0.returnKeyType = .search
+            $0.addLeftPadding(18)
+            $0.layer.borderColor = UIColor.gray03.cgColor
+            $0.layer.borderWidth = 1
+            $0.setRightIcon(IconLiterals.ic_search_gray)
+        }
+    }
+
+    // MARK: - SetLayout
+
+    private func setLayout() {
+        menuButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(14)
+            $0.top.equalToSuperview().inset(14)
+            $0.width.height.equalTo(24)
+        }
+
+        searchTextField.snp.makeConstraints {
+            $0.leading.equalTo(menuButton.snp.trailing).offset(29)
+            $0.centerY.equalTo(menuButton)
+            $0.trailing.equalToSuperview().inset(46)
+            $0.height.equalTo(40)
+        }
+    }
+}

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/HomeViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/HomeViewController.swift
@@ -104,7 +104,7 @@ final class HomeViewController: UIViewController {
         }
 
         categoryTopTabBar.snp.makeConstraints {
-            $0.top.equalTo(topSearchHeaderView.snp.bottom).offset(5)
+            $0.top.equalTo(topSearchHeaderView.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(40)
         }
@@ -173,7 +173,7 @@ final class HomeViewController: UIViewController {
             self.topSearchHeaderView.isHidden = hidden
 
             self.categoryTopTabBar.snp.remakeConstraints {
-                $0.top.equalTo(hidden ? self.view.safeAreaLayoutGuide : self.topSearchHeaderView.snp.bottom)
+                $0.top.equalTo(hidden ? self.view.safeAreaLayoutGuide : self.topSearchHeaderView.snp.bottom).offset(hidden ? 0 : 10)
                 $0.leading.trailing.equalToSuperview()
                 $0.height.equalTo(40)
             }
@@ -188,13 +188,27 @@ final class HomeViewController: UIViewController {
     }
 }
 
+
 // MARK: - UICollectionView Delegate & DataSource
 
 extension HomeViewController: UICollectionViewDelegate {
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let offset = scrollView.contentOffset.y
-        setTopHeader(hidden: offset > hideThreshold)
+
+        // Top 헤더 숨김 처리
+        let offsetY = scrollView.contentOffset.y
+        setTopHeader(hidden: offsetY > hideThreshold)
+
+        // Banner Section Indicator 사라짐 처리
+        let hideThreshold: CGFloat = 30
+        let shouldHide = offsetY > hideThreshold
+        UIView.animate(withDuration: 0.2) {
+            self.bannerPageLabel.alpha = shouldHide ? 0 : 1
+            self.bannerPageIndicatorImageView.alpha = shouldHide ? 0 : 1
+        } completion: { _ in
+            self.bannerPageLabel.isHidden = shouldHide
+            self.bannerPageIndicatorImageView.isHidden = shouldHide
+        }
         updateBannerOverlayPosition()
     }
 

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/HomeViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/HomeViewController.swift
@@ -76,6 +76,7 @@ final class HomeViewController: UIViewController {
             $0.delegate = self
             $0.dataSource = self
             $0.showsHorizontalScrollIndicator = false
+            $0.showsVerticalScrollIndicator = false
         }
 
         bannerPageLabel.do {

--- a/HOLIX_iOS/HOLIX_iOS/View/Home/Layout/HomeSectionLayoutFactory.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Home/Layout/HomeSectionLayoutFactory.swift
@@ -8,8 +8,7 @@
 import UIKit
 
 enum HomeSectionType: Int, CaseIterable {
-    case searchCategory = 0
-    case banner
+    case banner = 0
     case categoryBoxMenu
     case popularStudy
 }
@@ -19,10 +18,7 @@ struct HomeSectionLayoutFactory {
     static func create() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { sectionNumber, _ in
             let section: NSCollectionLayoutSection
-
             switch HomeSectionType(rawValue: sectionNumber) {
-            case .searchCategory:
-                section = makeSearchCategorySection()
             case .banner:
                 section = makeBannerSection()
             case .categoryBoxMenu:

--- a/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
@@ -17,7 +17,7 @@ class MyClubMainViewController: UIViewController {
 
     // MARK: - UI Components
 
-    private let topTabBar = TopTabBarView(items: ["내 클럽", "클래스", "멘토링"])
+    private let topTabBar = CategoryTabBarView(items: ["내 클럽", "클래스", "멘토링"])
 
     // MARK: - LifeCycle
 


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
Home 화면 UI 구성 리팩터링 작업을 진행 하였습니다!
## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->

- Topbar -> Sticky header로 리팩토링
- 기기별 확인 -> Sticky header 오른쪽 offset 지정 
- banner Section indicator가 Sticky header 영역 침범하는 문제 해결
- 작업 파일 접근 제어자 및 final 키워드 확인
- homeCollectionView showsVerticalScrollIndicator 지우기

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
사실 어떻게 Sticky header를 구현해야하나 고민이 많았습니다.. 트러블 슈팅과 코드 설명을 함께 달아 두었습니다.
https://amused-flax-90b.notion.site/Sticky-header-1f93310a471480acb4ace855be68f986

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| HomeView | <img src = "https://github.com/user-attachments/assets/a4b8ee02-8628-4689-ae7c-17173c1dce4f" width ="250"> | <img src = "https://github.com/user-attachments/assets/2fca0b97-42ca-4dd2-97b1-2efeb436b63d" width ="250"> | <img src = "https://github.com/user-attachments/assets/1733d3ea-b74a-4c19-8dd6-de3eb2e22b07" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
설계에 대한 아이디어가 있다면 말씀해주시고 리팩토링 관련해서 제안 주실 부분 있으시면 다 말씀해주셨으면 좋겠습니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`HomeView`
- 스티키 관련 Properties, UI Components
```swift
// MARK: - Properties

private let hideThreshold: CGFloat = 80
private var isTopHeaderHidden = false

// MARK: - UI Components
        
private let topSearchHeaderView = SearchBarHeaderView()
private let categoryTopTabBar = CategoryTabBarView(...)
```

- 흐름: 스크롤 시 이 헤더들이 어떻게 동작하나?
```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
    let offsetY = scrollView.contentOffset.y

    // 일정 높이 이상이면 숨김
    setTopHeader(hidden: offsetY > hideThreshold)
}
```
let offsetY = scrollView.contentOffset.y
스크롤 위치를 가져옴 

offsetY는 화면을 얼마나 아래로 스크롤했는지를 나타내는 숫자
0이면 맨 위, 숫자가 커질수록 더 아래로 스크롤한 상태.
offsetY > hideThreshold → 80 이상 스크롤 되면 topSearchHeaderView와 categoryTopTabBar를 숨김

- 흐름: 스크롤 시 이 헤더가 사라지고 보이게 만드는 함수
```swift
private func setTopHeader(hidden: Bool) {
    guard hidden != isTopHeaderHidden else { return } // 상태 바뀔 때만 작동
    isTopHeaderHidden = hidden

    UIView.animate(withDuration: 0.3) {
        self.topSearchHeaderView.alpha = hidden ? 0 : 1
        self.topSearchHeaderView.isHidden = hidden

        self.categoryTopTabBar.snp.remakeConstraints {
            $0.top.equalTo(hidden ? self.view.safeAreaLayoutGuide : self.topSearchHeaderView.snp.bottom)
                .offset(hidden ? 0 : 10)
        }

        self.homeCollectionView.snp.remakeConstraints {
            $0.top.equalTo(self.categoryTopTabBar.snp.bottom)
        }

        self.view.layoutIfNeeded()
    }
}
```
- alpha 값으로 자연스럽게 숨김
- isHidden으로 완전히 감춤
- SnapKit remakeConstraints로 레이아웃 다시 잡음:
    - 숨기면 categoryTopTabBar가 바로 safeArea 아래로 이동
    - 보여주면 topSearchHeaderView 아래로 다시 이동 (+10)
    - 즉, 상단 헤더가 사라지면 탭바가 올라오고, 다시 스크롤 올리면 탭바는 내려가고 헤더가 다시 보이는 구조

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #22 
