### PR TITLE
[Feat] MyClub, ClubDetailView 연결

### DIFF
--- a/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
+++ b/HOLIX_iOS/HOLIX_iOS.xcodeproj/project.pbxproj
@@ -58,10 +58,7 @@
 		465E84D62DDCAD0100FF05BF /* DividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465E84D12DDCAD0100FF05BF /* DividerView.swift */; };
 		46718D3C2DDF44DD0095098E /* ClubDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46718D3B2DDF44DD0095098E /* ClubDetailResponse.swift */; };
 		46718D3E2DDF45420095098E /* ClubChattingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46718D3D2DDF45420095098E /* ClubChattingService.swift */; };
-		46718D552DDF6E890095098E /* RecommendedClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46718D542DDF6E890095098E /* RecommendedClubModel.swift */; };
-		46718D562DDF6E890095098E /* MyClubModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46718D532DDF6E890095098E /* MyClubModel.swift */; };
 		46718D582DDF82EC0095098E /* ClubChattingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46718D572DDF82EC0095098E /* ClubChattingResponse.swift */; };
-		46718EC92DDF97220095098E /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 46718EC82DDF97220095098E /* Kingfisher */; };
 		468B02882DD411DF00A90492 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468B02872DD411DF00A90492 /* UIColor+.swift */; };
 		468B03252DD425BD00A90492 /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468B03242DD425BD00A90492 /* CustomNavigationBar.swift */; };
 		468B03792DD4341200A90492 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468B03782DD4341200A90492 /* TestViewController.swift */; };
@@ -123,8 +120,6 @@
 		465E84D12DDCAD0100FF05BF /* DividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerView.swift; sourceTree = "<group>"; };
 		46718D3B2DDF44DD0095098E /* ClubDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailResponse.swift; sourceTree = "<group>"; };
 		46718D3D2DDF45420095098E /* ClubChattingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubChattingService.swift; sourceTree = "<group>"; };
-		46718D532DDF6E890095098E /* MyClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubModel.swift; sourceTree = "<group>"; };
-		46718D542DDF6E890095098E /* RecommendedClubModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedClubModel.swift; sourceTree = "<group>"; };
 		46718D572DDF82EC0095098E /* ClubChattingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubChattingResponse.swift; sourceTree = "<group>"; };
 		468B02872DD411DF00A90492 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		468B03242DD425BD00A90492 /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
@@ -137,28 +132,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-
-			path = Home;
-			sourceTree = "<group>";
-		};
-		46718D492DDF66FE0095098E /* MyClub */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = MyClub;
-			sourceTree = "<group>";
-		};
-		46EAB1EF2DD5C9060084C5A8 /* ClubDetail */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ClubDetail;
-
-			path = CategoryTabBar;
-
-			sourceTree = "<group>";
-		};
 		B06030202DD2660C002205F5 /* Font */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Font;
+			sourceTree = "<group>";
+		};
+		B0A41F042DE036FF000D128A /* CategoryTabBar */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CategoryTabBar;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -168,9 +149,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
 				2FBBF60C2DDF055800862C0D /* Kingfisher in Frameworks */,
-
 				2F5B869D2DCDD3D500C3ABF6 /* SnapKit in Frameworks */,
 				2F5B86A22DCDD3E000C3ABF6 /* Then in Frameworks */,
 			);
@@ -221,9 +200,7 @@
 		2F5B868D2DCDD37F00C3ABF6 /* View */ = {
 			isa = PBXGroup;
 			children = (
-
 				2FBBF54B2DDEF4FB00862C0D /* MyClub */,
-
 				4646CA842DD6FDA400E21D3D /* Chatting */,
 				2FBBF60F2DDF0D3500862C0D /* ClubDetail */,
 				2FBBF6002DDEFEC000862C0D /* Home */,
@@ -248,7 +225,7 @@
 		2F5B86982DCDD3AE00C3ABF6 /* Component */ = {
 			isa = PBXGroup;
 			children = (
-				2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */,
+				B0A41F042DE036FF000D128A /* CategoryTabBar */,
 				468B03242DD425BD00A90492 /* CustomNavigationBar.swift */,
 				465E84392DDAE3ED00FF05BF /* CustomTextView.swift */,
 				465E848D2DDB67AB00FF05BF /* TagView.swift */,
@@ -337,10 +314,8 @@
 		2F648F672DDE1B3900A31931 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-
 				2FBBF5552DDEF54B00862C0D /* MyClubModel.swift */,
 				2FBBF5562DDEF54B00862C0D /* RecommendedClubModel.swift */,
-
 				2F648F642DDE1B3900A31931 /* BannerResponse.swift */,
 				2F648F652DDE1B3900A31931 /* CategoryBoxMenuResponse.swift */,
 			);
@@ -491,21 +466,14 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-
-				2F57841E2DD4446F0075A288 /* Home */,
-				46718D492DDF66FE0095098E /* MyClub */,
-
-				2FBBF5ED2DDEFE2E00862C0D /* CategoryTabBar */,
-
 				B06030202DD2660C002205F5 /* Font */,
+				B0A41F042DE036FF000D128A /* CategoryTabBar */,
 			);
 			name = HOLIX_iOS;
 			packageProductDependencies = (
 				2F5B869C2DCDD3D500C3ABF6 /* SnapKit */,
 				2F5B86A12DCDD3E000C3ABF6 /* Then */,
-
 				2FBBF60B2DDF055800862C0D /* Kingfisher */,
-
 			);
 			productName = HOLIX_iOS;
 			productReference = 2F5B86672DCDD05500C3ABF6 /* HOLIX_iOS.app */;
@@ -538,9 +506,7 @@
 			packageReferences = (
 				2F5B869B2DCDD3D500C3ABF6 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				2F5B86A02DCDD3E000C3ABF6 /* XCRemoteSwiftPackageReference "Then" */,
-
 				2FBBF60A2DDF055800862C0D /* XCRemoteSwiftPackageReference "Kingfisher" */,
-
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2F5B86682DCDD05500C3ABF6 /* Products */;
@@ -600,9 +566,7 @@
 				2F5B86922DCDD37F00C3ABF6 /* AppDelegate.swift in Sources */,
 				2F57841C2DD43EB20075A288 /* UIView.swift in Sources */,
 				2F5783402DD34C270075A288 /* ImageLiterals.swift in Sources */,
-
 				46718D3C2DDF44DD0095098E /* ClubDetailResponse.swift in Sources */,
-
 				2FBBF6012DDEFEC000862C0D /* BannerCell.swift in Sources */,
 				2FBBF6022DDEFEC000862C0D /* CategoryBoxCell.swift in Sources */,
 				2FBBF6032DDEFEC000862C0D /* ContentCardCell.swift in Sources */,
@@ -612,7 +576,6 @@
 				2FBBF6052DDEFEC000862C0D /* HomeSectionHeader.swift in Sources */,
 				2FBBF6062DDEFEC000862C0D /* HomeSectionLayoutFactory.swift in Sources */,
 				2FBBF6072DDEFEC000862C0D /* HomeViewController.swift in Sources */,
-
 				4646CA862DD6FDDF00E21D3D /* ChattingViewController.swift in Sources */,
 				4646CB632DD7397900E21D3D /* ChattingMockData.swift in Sources */,
 				B09D88602DD47B8300AD423E /* NSAttributedString+Pretendard.swift in Sources */,
@@ -637,11 +600,6 @@
 				2F648F5F2DDE1ACD00A31931 /* APIService.swift in Sources */,
 				2F648F682DDE1B3900A31931 /* BannerResponse.swift in Sources */,
 				2F648F692DDE1B3900A31931 /* CategoryBoxMenuResponse.swift in Sources */,
-
-				2F648F6A2DDE1B3900A31931 /* HomeItemResponse.swift in Sources */,
-				46718D552DDF6E890095098E /* RecommendedClubModel.swift in Sources */,
-				46718D562DDF6E890095098E /* MyClubModel.swift in Sources */,
-
 				2F648F602DDE1ACD00A31931 /* HTTPMethod.swift in Sources */,
 				2F648F612DDE1ACD00A31931 /* NetworkError.swift in Sources */,
 				2F648F622DDE1ACD00A31931 /* HomeService.swift in Sources */,
@@ -687,6 +645,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -720,6 +679,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -900,11 +860,9 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-
 		2FBBF60A2DDF055800862C0D /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
-
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 8.3.2;
@@ -923,11 +881,9 @@
 			package = 2F5B86A02DCDD3E000C3ABF6 /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
 		};
-
 		2FBBF60B2DDF055800862C0D /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2FBBF60A2DDF055800862C0D /* XCRemoteSwiftPackageReference "Kingfisher" */;
-
 			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CategoryTabBar/CategoryTabBarView.swift
@@ -114,7 +114,7 @@ final class CategoryTabBarView: UIView {
 
         indicatorLeadingConstraint?.update(offset: cellFrame.origin.x)
         indicatorWidthConstraint?.update(offset: cellFrame.width)
-        
+
         UIView.animate(withDuration: 0.2) {
             self.tabCollectionView.layoutIfNeeded()
         }

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
@@ -138,7 +138,6 @@ final class CustomNavigationBar: UIView {
 
     func setTitle(_ title: String) {
         self.titleLabel.text = title
-        print("🔥title: ", title)
     }
 
     // MARK: - Button Actions

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
@@ -114,6 +114,7 @@ final class CustomNavigationBar: UIView {
         titleLabel.snp.makeConstraints {
             $0.leading.equalTo(self.backButton.snp.trailing).offset(16)
             $0.centerY.equalToSuperview()
+            $0.width.equalTo(240)
         }
 
         buttonStackView.snp.makeConstraints {

--- a/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
+++ b/HOLIX_iOS/HOLIX_iOS/Global/Component/CustomNavigationBar.swift
@@ -41,7 +41,6 @@ final class CustomNavigationBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-
     init(titleLabel: String = "", hasMenuButton: Bool, tintColor: UIColor = .black) {
 
         super.init(frame: .zero)
@@ -134,6 +133,11 @@ final class CustomNavigationBar: UIView {
         searchButton.addTarget(self, action: #selector(searchButtonDidTap), for: .touchUpInside)
         menuButton.addTarget(self, action: #selector(menuButtonDidTap), for: .touchUpInside)
 
+    }
+
+    func setTitle(_ title: String) {
+        self.titleLabel.text = title
+        print("🔥title: ", title)
     }
 
     // MARK: - Button Actions

--- a/HOLIX_iOS/HOLIX_iOS/NetWork/Response/ClubChattingResponse.swift
+++ b/HOLIX_iOS/HOLIX_iOS/NetWork/Response/ClubChattingResponse.swift
@@ -40,13 +40,13 @@ struct Chatting: Codable {
             "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
             "yyyy-MM-dd'T'HH:mm:ss"
         ]
-        
+
         for format in formats {
             let formatter = DateFormatter()
             formatter.dateFormat = format
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(secondsFromGMT: 0)
-            
+
             if let date = formatter.date(from: createdAt) {
                 let displayFormatter = DateFormatter()
                 displayFormatter.dateFormat = "HH:mm"

--- a/HOLIX_iOS/HOLIX_iOS/NetWork/Services/ClubChattingService.swift
+++ b/HOLIX_iOS/HOLIX_iOS/NetWork/Services/ClubChattingService.swift
@@ -17,7 +17,7 @@ final class ClubChattingService {
             method: Endpoint.Club.getClubDetail(clubId: clubId).method,
             responseType: ClubDetailResponse.self)
     }
-    
+
     func getClubChatting(clubId: String) async throws -> ClubChattingResponse {
         return try await APIService.shared.request(
             path: Endpoint.Club.getClubChat(clubId: clubId).path,

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/ChattingCell.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingCell/ChattingCell.swift
@@ -22,7 +22,7 @@ class ChattingCell: UITableViewCell {
     private var isSender = true
 
     private var profileImageURL: String?
-    
+
 
     // MARK: - UI Components
 

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
@@ -24,7 +24,7 @@ final class ChattingViewController: UIViewController {
         hasMenuButton: true
     )
 
-    
+
     private var chattingList = [Chatting]() {
         didSet {
             DispatchQueue.main.async {
@@ -232,7 +232,7 @@ extension ChattingViewController {
             return nil
         }
     }
-    
+
     func loadChatting(clubId: String) {
         Task {
             do {

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
@@ -44,8 +44,8 @@ final class ChattingViewController: UIViewController {
         setLayout()
         setupTableView()
         tagScrollView()
+        setDelegate()
         setupDismissKeyboardGesture()
-        loadChatting(clubId: "1")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -133,6 +133,12 @@ final class ChattingViewController: UIViewController {
         textView.addTag(title: "UIK12312it")
         textView.addTag(title: "Swi1ft")
         textView.addTag(title: "UIKit")
+    }
+
+    // MARK: - SetDelegate
+
+    private func setDelegate() {
+        customNavigationBar.delegate = self
     }
 }
 
@@ -249,4 +255,15 @@ extension ChattingViewController {
             }
         }
     }
+}
+
+// MARK: - CustomNavigationBarDelegate
+
+extension ChattingViewController: CustomNavigationBarDelegate {
+    func didTapBackButton() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    func didTapSearchButton() {}
+    func didTapMenuButton() {}
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
@@ -16,14 +16,14 @@ final class ChattingViewController: UIViewController {
 
     private var customTextViewHeightConstraint: Constraint?
     private var customTextViewBottomConstraint: Constraint?
+    var clubTitle: String?
 
     // MARK: - UI Components
 
     private let customNavigationBar = CustomNavigationBar(
-        titleLabel:"iOS 개발자로써 성공하고 싶은 사람들",
+        titleLabel: "",
         hasMenuButton: true
     )
-
 
     private var chattingList = [Chatting]() {
         didSet {
@@ -67,6 +67,9 @@ final class ChattingViewController: UIViewController {
                 tableView,
                 textView
             )
+        if let clubTitle = clubTitle {
+            customNavigationBar.setTitle(clubTitle)
+        }
     }
 
     // MARK: - SetStyle

--- a/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/Chatting/ChattingViewController.swift
@@ -221,6 +221,8 @@ extension ChattingViewController {
 
 }
 
+// MARK: - Fetching & Loading
+
 extension ChattingViewController {
     func fetchClubChatting(clubId: String) async throws -> ClubChattingResponse? {
         do {

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
@@ -14,6 +14,7 @@ import Then
 final class ClubDetailViewController: UIViewController {
 
     // MARK: - UI Components
+
     private let customNavigationBar = CustomNavigationBar(hasMenuButton: false)
     private let iconImageView = UIImageView()
     private let clubInfoView = ClubInfoView()
@@ -81,8 +82,21 @@ final class ClubDetailViewController: UIViewController {
     }
 
     // MARK: - SetDelegate
+
     private func setDelegate() {
         customNavigationBar.delegate = self
+        clubInfoView.onEnterButtonTapped = { [weak self] clubId in
+            self?.navigateToChatting(clubId: clubId)
+        }
+    }
+
+    // MARK: - navigateToChatting
+
+    private func navigateToChatting(clubId: String) {
+        let vc = ChattingViewController()
+        vc.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(vc, animated: true)
+        vc.loadChatting(clubId: clubId)
     }
 }
 

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
@@ -82,7 +82,7 @@ final class ClubDetailViewController: UIViewController {
 
 
 extension ClubDetailViewController {
-    
+
     func fetchClubDetail(clubId: String) async throws -> ClubDetailResponse? {
         do {
             let detail = try await ClubChattingService.shared.getClubDetail(clubId: clubId)
@@ -93,7 +93,7 @@ extension ClubDetailViewController {
             return nil
         }
     }
-    
+
     func loadClubInfo(clubId: String) {
         Task {
             do {
@@ -108,7 +108,7 @@ extension ClubDetailViewController {
         }
     }
 
-    
+
     func updateUI(with detail: ClubDetailResponse) {
         clubInfoView.configure(with: detail)
         if let url = URL(string: detail.data.url) {

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
@@ -25,6 +25,7 @@ final class ClubDetailViewController: UIViewController {
         setUI()
         setStyle()
         setLayout()
+        setDelegate()
     }
 
     // MARK: - SetUI
@@ -78,8 +79,12 @@ final class ClubDetailViewController: UIViewController {
             $0.leading.trailing.bottom.equalToSuperview()
         }
     }
-}
 
+    // MARK: - SetDelegate
+    private func setDelegate() {
+        customNavigationBar.delegate = self
+    }
+}
 
 extension ClubDetailViewController {
 
@@ -108,11 +113,21 @@ extension ClubDetailViewController {
         }
     }
 
-
     func updateUI(with detail: ClubDetailResponse) {
         clubInfoView.configure(with: detail)
         if let url = URL(string: detail.data.url) {
             iconImageView.kf.setImage(with: url)
         }
     }
+}
+
+// MARK: - Delegate
+
+extension ClubDetailViewController: CustomNavigationBarDelegate {
+    func didTapBackButton() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    func didTapSearchButton() {}
+    func didTapMenuButton() {}
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
@@ -25,7 +25,6 @@ final class ClubDetailViewController: UIViewController {
         setUI()
         setStyle()
         setLayout()
-        loadClubInfo(clubId: "3")
     }
 
     // MARK: - SetUI

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubDetailViewController.swift
@@ -34,7 +34,6 @@ final class ClubDetailViewController: UIViewController {
     private func setUI() {
         self.view.addSubviews(customNavigationBar,iconImageView,clubInfoView)
         customNavigationBar.layer.zPosition = 1
-
     }
 
     // MARK: - SetStyle
@@ -85,16 +84,18 @@ final class ClubDetailViewController: UIViewController {
 
     private func setDelegate() {
         customNavigationBar.delegate = self
-        clubInfoView.onEnterButtonTapped = { [weak self] clubId in
-            self?.navigateToChatting(clubId: clubId)
+        clubInfoView.onEnterButtonTapped = { [weak self] clubId, clubTitle in
+            self?.navigateToChatting(clubId: clubId, title: clubTitle)
         }
     }
 
     // MARK: - navigateToChatting
 
-    private func navigateToChatting(clubId: String) {
+    private func navigateToChatting(clubId: String, title: String) {
         let vc = ChattingViewController()
+        vc.clubTitle = title
         vc.hidesBottomBarWhenPushed = true
+        vc.clubTitle = clubInfoView.currentClubTitle
         self.navigationController?.pushViewController(vc, animated: true)
         vc.loadChatting(clubId: clubId)
     }

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubInfoView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubInfoView.swift
@@ -20,8 +20,9 @@ final class ClubInfoView: UIView {
                       "ic_club_category_ios_quiz"]
 
     let labelTexts = ["모임", "멘토링", "클래스", "퀴즈"]
-    var onEnterButtonTapped: ((String) -> Void)?
+    var onEnterButtonTapped: ((String, String) -> Void)?
     private var currentClubId: String?
+    var currentClubTitle: String?
 
     // MARK: - UI Components
 
@@ -221,11 +222,8 @@ final class ClubInfoView: UIView {
     }
 
     @objc private func enterButtonDidTap() {
-        guard let id = currentClubId else {
-            print("clubId 없음")
-            return
-        }
-        onEnterButtonTapped?(id)
+        guard let id = currentClubId, let title = currentClubTitle else { return }
+        onEnterButtonTapped?(id, title)
     }
 }
 
@@ -235,5 +233,6 @@ extension ClubInfoView {
         memberLabel.text = detail.data.participants
         noticeButton.textLabel.text = detail.data.notice
         currentClubId = "\(detail.data.clubId)"
+        currentClubTitle = "\(detail.data.title)"
     }
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubInfoView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/ClubDetail/ClubInfoView.swift
@@ -20,6 +20,8 @@ final class ClubInfoView: UIView {
                       "ic_club_category_ios_quiz"]
 
     let labelTexts = ["모임", "멘토링", "클래스", "퀴즈"]
+    var onEnterButtonTapped: ((String) -> Void)?
+    private var currentClubId: String?
 
     // MARK: - UI Components
 
@@ -41,6 +43,7 @@ final class ClubInfoView: UIView {
         setUI()
         setStyle()
         setLayout()
+        setAddTarget()
     }
 
     required init?(coder: NSCoder) {
@@ -60,7 +63,6 @@ final class ClubInfoView: UIView {
             enterButton,
             speechBubble
         )
-
     }
 
     // MARK: - SetStyle
@@ -211,6 +213,20 @@ final class ClubInfoView: UIView {
 
         return stackView
     }
+
+    // MARK: - SetAddTarget
+
+    private func setAddTarget() {
+        enterButton.addTarget(self, action: #selector(enterButtonDidTap), for: .touchUpInside)
+    }
+
+    @objc private func enterButtonDidTap() {
+        guard let id = currentClubId else {
+            print("clubId 없음")
+            return
+        }
+        onEnterButtonTapped?(id)
+    }
 }
 
 extension ClubInfoView {
@@ -218,5 +234,6 @@ extension ClubInfoView {
         titleLabel.text = detail.data.title
         memberLabel.text = detail.data.participants
         noticeButton.textLabel.text = detail.data.notice
+        currentClubId = "\(detail.data.clubId)"
     }
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/MyClub/View/MyClubView.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/MyClub/View/MyClubView.swift
@@ -17,6 +17,7 @@ final class MyClubView: UIView {
     private var itemData: [Club] = []
     final let cellWidth: CGFloat = UIScreen.main.bounds.width * 165 / 375
     final let cellHeight: CGFloat = 174
+    var onClubTapped: ((String) -> Void)?
 
     // MARK: - UI Components
 
@@ -73,6 +74,14 @@ final class MyClubView: UIView {
 
 // MARK: - UICollectionView Delegate & DataSource
 
+extension MyClubView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let selectedClub = itemData[indexPath.item]
+        print("선택된 클럽: ", selectedClub.clubId)
+        onClubTapped?("\(selectedClub.clubId)")
+    }
+}
+
 extension MyClubView: UICollectionViewDelegateFlowLayout {
     func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt _: IndexPath) -> CGSize {
 
@@ -95,9 +104,9 @@ extension MyClubView: UICollectionViewDataSource {
 }
 
 extension MyClubView {
-    
+
     // MARK: - caculateHeight
-    
+
     func calculatedHeight() -> CGFloat {
             let itemCount = itemData.count
             let rows = Int(ceil(Double(itemCount) / 2.0))
@@ -106,7 +115,7 @@ extension MyClubView {
 
             return CGFloat(rows) * (cellHeight + spacing) - spacing + inset
     }
-    
+
     // MARK: - updateData
 
     func updateData(_ clubs: [Club]) {

--- a/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
@@ -32,6 +32,7 @@ class MyClubMainViewController: UIViewController {
         setStyle()
         setLayout()
         fetchClubData()
+        setActions()
     }
 
     override func viewDidLayoutSubviews() {
@@ -105,5 +106,21 @@ class MyClubMainViewController: UIViewController {
                 print("클럽 데이터 불러오기 실패: \(error)")
             }
         }
+    }
+    
+    // MARK: - setActions
+    
+    private func setActions() {
+        myClub.onClubTapped = { [weak self] clubId in
+            self?.navigateToClubDetail(clubId: clubId)
+        }
+    }
+
+    // MARK: - navigateToClubDetail
+    
+    private func navigateToClubDetail(clubId: String) {
+        let detailVC = ClubDetailViewController()
+            self.navigationController?.pushViewController(detailVC, animated: true)
+            detailVC.loadClubInfo(clubId: clubId)
     }
 }

--- a/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
+++ b/HOLIX_iOS/HOLIX_iOS/View/MyClub/ViewController/MyClubMainViewController.swift
@@ -107,9 +107,9 @@ class MyClubMainViewController: UIViewController {
             }
         }
     }
-    
+
     // MARK: - setActions
-    
+
     private func setActions() {
         myClub.onClubTapped = { [weak self] clubId in
             self?.navigateToClubDetail(clubId: clubId)
@@ -117,10 +117,11 @@ class MyClubMainViewController: UIViewController {
     }
 
     // MARK: - navigateToClubDetail
-    
+
     private func navigateToClubDetail(clubId: String) {
         let detailVC = ClubDetailViewController()
-            self.navigationController?.pushViewController(detailVC, animated: true)
-            detailVC.loadClubInfo(clubId: clubId)
+        detailVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(detailVC, animated: true)
+        detailVC.loadClubInfo(clubId: clubId)
     }
 }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
MyClubCell을 터치했을 때 id에 대응하는 DetailView로 넘어가는 작업을 했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- MyClubView의 셀 터치 시, 대응하는 ClubDetailView로 이동하도록 설정
- ClubDetailView 이동 시 하단의 MainTabBarController 숨겨지도록 설정
- DetailView 입장 버튼 터치 시, 대응하는 ChattingView로 이동하도록 설정
- ChattingView 입장 시, ClubTitle 넘겨 받도록 설정
- ClubDetailView, ChattingView에서 BackButton 클릭 시 View가 pop 되어 사라지도록 설정
- CustomNavigation titleLabel 잘리는 현상 수정

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | ![ViewFlow SE](https://github.com/user-attachments/assets/fdd48321-862f-4ff5-941b-ec6fba13e1bd) | ![ViewFlow 13 mini](https://github.com/user-attachments/assets/6a721434-e6a1-4389-9716-348509362c78) | ![ViewFlow 15 pro](https://github.com/user-attachments/assets/a816985f-2eae-4636-94c9-b1b263c11354) |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`MyClubView`
- 특정 셀 클릭 시 대응하는 DetailView로 넘어갈 수 있도록 delegate 작업을 진행했습니다
```swift
extension MyClubView: UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let selectedClub = itemData[indexPath.item]
        print("선택된 클럽: ", selectedClub.clubId)
        onClubTapped?("\(selectedClub.clubId)")
    }
}
```

`MyClubMainViewController`
- 셀이 클릭하는 경우 delegate한 작업을 ViewController에서 처리하여 detailViewController가 화면에 Push될 수 있도록 작업했습니다. 이 때, 아래 사진과 같이 MainTabBarController가 화면에 함께 나타나는 현상이 발생하여 `detailVC.hidesBottomBarWhenPushed = true`를 통해 해결했습니다

<img width="475" alt="image" src="https://github.com/user-attachments/assets/0431d2ac-d1dc-4a82-a329-5a8610395e29" />

```swift
private func setActions() {
        myClub.onClubTapped = { [weak self] clubId in
            self?.navigateToClubDetail(clubId: clubId)
        }
    }

    // MARK: - navigateToClubDetail

    private func navigateToClubDetail(clubId: String) {
        let detailVC = ClubDetailViewController()
        detailVC.hidesBottomBarWhenPushed = true
        self.navigationController?.pushViewController(detailVC, animated: true)
        detailVC.loadClubInfo(clubId: clubId)
    }
```

`ClubDetailViewController`
- setDelegate 함수를 추가해 customNavigationBar의 동작을 제대로 수행할 수 있도록 해주었습니다
```swift
 private func setDelegate() {
        customNavigationBar.delegate = self
    }
```
```swift
extension ClubDetailViewController: CustomNavigationBarDelegate {
    func didTapBackButton() {
        navigationController?.popViewController(animated: true)
    }

    func didTapSearchButton() {}
    func didTapMenuButton() {}
}
```

- DetailView에서 ChattingView로 넘어갈 때 title을 지정해주는 코드가 없어서 clubId를 지정해주는 것과, title을 지정해주는 작업을 진행했습니다
`CustomNavigationBar`
```swift
func setTitle(_ title: String) {
        self.titleLabel.text = title
}
```
`ChattingViewController`
```swift
var clubTitle: String?
```
```swift
if let clubTitle = clubTitle {
      customNavigationBar.setTitle(clubTitle)
}
```
`ClubDetailViewController`
```
// MARK: - SetDelegate

    private func setDelegate() {
        customNavigationBar.delegate = self
        clubInfoView.onEnterButtonTapped = { [weak self] clubId, clubTitle in
            self?.navigateToChatting(clubId: clubId, title: clubTitle)
        }
    }

    // MARK: - navigateToChatting

    private func navigateToChatting(clubId: String, title: String) {
        let vc = ChattingViewController()
        vc.clubTitle = title
        vc.hidesBottomBarWhenPushed = true
        vc.clubTitle = clubInfoView.currentClubTitle
        self.navigationController?.pushViewController(vc, animated: true)
        vc.loadChatting(clubId: clubId)
    }
```
`ClubInfoView`
```swift
var onEnterButtonTapped: ((String, String) -> Void)?
```
```
// MARK: - SetAddTarget

    private func setAddTarget() {
        enterButton.addTarget(self, action: #selector(enterButtonDidTap), for: .touchUpInside)
    }

    @objc private func enterButtonDidTap() {
        guard let id = currentClubId, let title = currentClubTitle else { return }
        onEnterButtonTapped?(id, title)
    }
}

extension ClubInfoView {
    func configure(with detail: ClubDetailResponse) {
        titleLabel.text = detail.data.title
        memberLabel.text = detail.data.participants
        noticeButton.textLabel.text = detail.data.notice
        currentClubId = "\(detail.data.clubId)"
        currentClubTitle = "\(detail.data.title)"
    }
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #35 
